### PR TITLE
Add content type for targeted messages

### DIFF
--- a/draft-ietf-mls-extensions.md
+++ b/draft-ietf-mls-extensions.md
@@ -234,10 +234,10 @@ separate different payload types on the protocol level.
 
 ~~~
 struct {
-		select (TargetedMessage.content_type) {
-				case application:
-						opaque application_data<V>;
-		}
+	select (TargetedMessage.content_type) {
+			case application:
+					opaque application_data<V>;
+	}
 } TargetedMessageTBE;
 ~~~
 

--- a/draft-ietf-mls-extensions.md
+++ b/draft-ietf-mls-extensions.md
@@ -169,11 +169,18 @@ The `TargetedMessage` message type is defined as follows:
 struct {
   opaque group_id<V>;
   uint64 epoch;
+  TargetedMessageContentType content_type;
   uint32 recipient_leaf_index;
   opaque authenticated_data<V>;
   opaque encrypted_sender_auth_data<V>;
   opaque hpke_ciphertext<V>;
 } TargetedMessage;
+
+enum {
+  reserved(0),
+  application(1),
+  (255)
+} TargetedMessageContentType
 
 enum {
   hpke_auth_psk(0),
@@ -220,9 +227,21 @@ struct {
 Note that `TargetedMessageTBS` is only used with the
 `TargetedMessageAuthScheme.SignatureHPKEPsk` authentication mode.
 
+Other MLS extensions can use the `content_type` field in `TargetedMessage` to
+separate different payload types on the protocol level.
+
 ### Encryption
 
-Targeted messages use HPKE to encrypt the message content between two leaves.
+~~~
+struct {
+		select (TargetedMessage.content_type) {
+				case application:
+						opaque application_data<V>;
+		}
+} TargetedMessageTBE;
+~~~
+
+Targeted messages use HPKE to encrypt `TargetedMessageTBE` between two leaves.
 The HPKE keys of the `LeafNode` are used to that effect, namely the
 `encryption_key` field.
 

--- a/draft-ietf-mls-extensions.md
+++ b/draft-ietf-mls-extensions.md
@@ -234,10 +234,10 @@ separate different payload types on the protocol level.
 
 ~~~
 struct {
-	select (TargetedMessage.content_type) {
-			case application:
-					opaque application_data<V>;
-	}
+  select (TargetedMessage.content_type) {
+    case application:
+    	opaque application_data<V>;
+  }
 } TargetedMessageTBE;
 ~~~
 


### PR DESCRIPTION
Adding a content_type field to TargetedMessages allows other extensions to use them without fear of protocol confusion attacks. The alternative would be to use the content advertisement mechanism, which doesn't seem particularly clean, however, as we'd be mixing protocol and application level.

This is a draft as basis for further discussion. Especially the IANA considerations for the content type enum are missing.