### PR TITLE
Streamline targeted messages

### DIFF
--- a/draft-ietf-mls-extensions.md
+++ b/draft-ietf-mls-extensions.md
@@ -935,7 +935,7 @@ to be sent, and the `padding` field contains padding bytes to ensure that the
 ciphertext is of a length that is a multiple of the AEAD tag length.
 
 The `TargetedMessageContent` struct is serialized and then encrypted
-using HPKE. 
+using HPKE.
 
 The HPKE context is a TargetedMessageContext struct with the
 following content, where `group_context` is the serialized context of the MLS

--- a/draft-ietf-mls-extensions.md
+++ b/draft-ietf-mls-extensions.md
@@ -864,6 +864,14 @@ targeted_message_psk =
 
 The pre-shared key is then used as an input to the HPKE encryption.
 
+#### Additional Authenticated Data (AAD)
+
+Targeted messages can include additional authenticated data (AAD) in the
+`TargetedMessage.authenticated_data` field. This field is used to carry
+application-specific data that is authenticated but not encrypted. The AAD is
+included in the `TargetedMessagesTBM` struct, which in turn is serialized and is
+used as the `info` parameter for the HPKE handshake..
+
 ### Encryption
 
 Targeted messages uses HPKE to encrypt the message content between two leaves.
@@ -969,6 +977,8 @@ targeted_message_content = OpenPSK(kem_output,
 ~~~
 
 The functions `SealPSK` and `OpenPSK` are defined in {{!RFC9180}}.
+The parameters named `targeted_message_*` are the serialized representations of
+the corresponding structs named `TargetedMessage*` defined above.
 
 ## Content Advertisement
 

--- a/draft-ietf-mls-extensions.md
+++ b/draft-ietf-mls-extensions.md
@@ -833,7 +833,7 @@ struct {
 
 ### Authentication
 
-Targeted messages are autheticated using a preshared key (PSK), exported through
+Targeted messages are authenticated using a preshared key (PSK), exported through
 the MLS exporter for the epoch specified in SenderAuthDataAAD.epoch:
 
 ~~~ tls

--- a/draft-ietf-mls-extensions.md
+++ b/draft-ietf-mls-extensions.md
@@ -833,16 +833,8 @@ struct {
 
 ### Authentication
 
-Targeted messages are authenticated using a preshared key (PSK), exported through
-the MLS exporter for the epoch specified in SenderAuthDataAAD.epoch:
-
-~~~ tls
-targeted_message_psk =
-  MLS-Exporter("targeted message", "psk", KDF.Nh)
-~~~
-
-In addition, and for non-repudiation, the sender signs the message using the
-signature key of the sender's `LeafNode`. The signature scheme used is the
+A targeted message is authenticated by the sender's signature. The sender uses
+the signature key of the its `LeafNode`. The signature scheme used is the
 signature scheme specified in the cipher suite of the MLS group. The signature
 is computed over the serialized `TargetedMessageTBS` struct and is included in
 the `TargetedMessageSenderAuthData.signature` field:
@@ -860,6 +852,17 @@ VerifyWithLabel.verify(sender_leaf_node.signature_key,
                        targeted_message_tbs,
                        signature)
 ~~~
+
+In addition, targeted messages are authenticated using a pre-shared key (PSK),
+exported through the MLS exporter for the epoch specified in
+SenderAuthDataAAD.epoch:
+
+~~~ tls
+targeted_message_psk =
+  MLS-Exporter("targeted message", "psk", KDF.Nh)
+~~~
+
+The pre-shared key is then used as an input to the HPKE encryption.
 
 ### Encryption
 
@@ -988,7 +991,7 @@ later in {{app-framing}}. This allows clients to confirm that all members of a
 group can communicate.
 
 >Note that when the membership of a group changes, or when the policy of the
- group changes, it is responsibility of the committer to ensure that the
+ group changes, it is the responsibility of the committer to ensure that the
  membership and policies are compatible.
 
 As clients are upgraded to support new formats they can use these extensions to


### PR DESCRIPTION
Simplifies targeted messages by eliminating the HPKE Auth mode and introduces padding.

Fixes #15, #57, #59.