### PR TITLE
Remove targeted messages

### DIFF
--- a/draft-ietf-mls-extensions.md
+++ b/draft-ietf-mls-extensions.md
@@ -760,254 +760,6 @@ generation is never observed. Obviously, there is a risk that AppAck messages
 could be suppressed as well, but their inclusion in the transcript means that if
 they are suppressed then the group cannot advance at all.
 
-
-## Targeted messages
-
-### Description
-
-MLS application messages make sending encrypted messages to all group members
-easy and efficient. Sometimes application protocols mandate that messages are
-only sent to specific group members, either for privacy or for efficiency
-reasons.
-
-Targeted messages are a way to achieve this without having to create a new group
-with the sender and the specific recipients – which might not be possible or
-desired. Instead, targeted messages define the format and encryption of a
-message that is sent from a member of an existing group to another member of
-that group.
-
-The goal is to provide a one-shot messaging mechanism that provides
-confidentiality and authentication, reusing mechanisms from {{!RFC9420}}, in
-particular {{!RFC9180}}.
-
-### Format
-
-This extension defines the `mls_targeted_message` WireFormat, where the content
-is a `TargetedMessage`.
-
-~~~ tls
-struct {
-  opaque group_id<V>;
-  uint64 epoch;
-  uint32 recipient_leaf_index;
-  opaque authenticated_data<V>;
-  opaque encrypted_sender_auth_data<V>;
-  opaque hpke_ciphertext<V>;
-} TargetedMessage;
-
-enum {
-  hpke_auth_psk(0),
-  signature_hpke_psk(1),
-} TargetedMessageAuthScheme;
-
-struct {
-  uint32 sender_leaf_index;
-  TargetedMessageAuthScheme authentication_scheme;
-  select (authentication_scheme) {
-    case HPKEAuthPsk:
-    case SignatureHPKEPsk:
-      opaque signature<V>;
-  }
-  opaque kem_output<V>;
-} TargetedMessageSenderAuthData;
-
-struct {
-  opaque group_id<V>;
-  uint64 epoch;
-  uint32 recipient_leaf_index;
-  opaque authenticated_data<V>;
-  TargetedMessageSenderAuthData sender_auth_data;
-} TargetedMessageTBM;
-
-struct {
-  opaque group_id<V>;
-  uint64 epoch;
-  uint32 recipient_leaf_index;
-  opaque authenticated_data<V>;
-  uint32 sender_leaf_index;
-  TargetedMessageAuthScheme authentication_scheme;
-  opaque kem_output<V>;
-  opaque hpke_ciphertext<V>;
-} TargetedMessageTBS;
-
-struct {
-  opaque group_id<V>;
-  uint64 epoch;
-  opaque label<V> = "MLS 1.0 targeted message psk";
-} PSKId;
-~~~
-
-Note that `TargetedMessageTBS` is only used with the
-`TargetedMessageAuthScheme.SignatureHPKEPsk` authentication mode.
-
-### Encryption
-
-Targeted messages uses HPKE to encrypt the message content between two leaves.
-
-#### Sender data encryption
-
-In addition, `TargetedMessageSenderAuthData` is encrypted similarly to
-`MLSSenderData` as described in {{Section 6.3.2 of !RFC9420}}. The
-`TargetedMessageSenderAuthData.sender_leaf_index` field is the leaf index of the
-sender. The `TargetedMessageSenderAuthData.authentication_scheme` field is the
-authentication scheme used to authenticate the sender. The
-`TargetedMessageSenderAuthData.signature` field is the signature of the
-`TargetedMessageTBS` structure. The `TargetedMessageSenderAuthData.kem_output`
-field is the KEM output of the HPKE encryption.
-
-The key and nonce provided to the AEAD are computed as the KDF of the first
-KDF.Nh bytes of the `hpke_ciphertext` generated in the following section. If the
-length of the hpke_ciphertext is less than KDF.Nh, the whole hpke_ciphertext is
-used. In pseudocode, the key and nonce are derived as:
-
-~~~ tls
-sender_auth_data_secret =
-  MLS-Exporter("targeted message", "sender auth data secret", KDF.Nh)
-
-ciphertext_sample = hpke_ciphertext[0..KDF.Nh-1]
-
-sender_data_key = ExpandWithLabel(sender_auth_data_secret, "key",
-                      ciphertext_sample, AEAD.Nk)
-sender_data_nonce = ExpandWithLabel(sender_auth_data_secret, "nonce",
-                      ciphertext_sample, AEAD.Nn)
-~~~
-
-The Additional Authenticated Data (AAD) for the `SenderAuthData` ciphertext is
-the first three fields of `TargetedMessage`:
-
-~~~ tls
-struct {
-  opaque group_id<V>;
-  uint64 epoch;
-  uint32 recipient_leaf_index;
-} SenderAuthDataAAD;
-~~~
-
-#### Padding
-
-The `TargetedMessage` structure does not include a padding field. It is the
-responsibility of the sender to add padding to the `message` as used in the next
-section.
-
-### Authentication
-
-For ciphersuites that support it, HPKE `mode_auth_psk` is used for
-authentication. For other ciphersuites, HPKE `mode_psk` is used along with a
-signature. The authentication scheme is indicated by the `authentication_scheme`
-field in `TargetedMessageContent`. See {{guidance-on-authentication-schemes}}
-for more information.
-
-For the PSK part of the authentication, clients export a dedicated secret:
-
-~~~ tls
-targeted_message_psk =
-  MLS-Exporter("targeted message", "psk", KDF.Nh)
-~~~
-
-The functions `SealAuth` and `OpenAuth` defined in {{!RFC9180}} are used as
-described in {{safe-hpke}} with an empty context. Other functions are defined in
-{{!RFC9420}}.
-
-#### Authentication with HPKE
-
-The sender MUST set the authentication scheme to
-`TargetedMessageAuthScheme.HPKEAuthPsk`.
-
-The `hpke_context` is an TargetedMessageContext struct with the following
-content, where `group_context` is the serialized context of the group.
-
-~~~ tls
-struct {
-  opaque label<V>;
-  opaque context<V>;
-} TargetedMessageContext;
-
-label = "MLS 1.0 TargetedMessageData"
-context = group_context
-~~~
-
-The sender then computes the following:
-
-~~~ tls
-(kem_output, hpke_ciphertext) = SealAuthPSK(receiver_node_public_key,
-                                            hpke_context,
-                                            targeted_message_tbm,
-                                            message,
-                                            targeted_message_psk,
-                                            psk_id,
-                                            sender_node_private_key)
-~~~
-
-The recipient computes the following:
-
-~~~ tls
-message = OpenAuthPSK(kem_output,
-                      receiver_node_private_key,
-                      hpke_context,
-                      targeted_message_tbm,
-                      hpke_ciphertext,
-                      targeted_message_psk,
-                      psk_id,
-                      sender_node_public_key)
-~~~
-
-#### Authentication with signatures
-
-The sender MUST set the authentication scheme to
-`TargetedMessageAuthScheme.SignatureHPKEPsk`. The signature is done using the
-`signature_key` of the sender's `LeafNode` and the corresponding signature
-scheme used in the group.
-
-The sender then computes the following with `hpke_context` defined as in
-{{authentication-with-hpke}}:
-
-~~~ tls
-(kem_output, hpke_ciphertext) = SealPSK(receiver_node_public_key,
-                                        hpke_context,
-                                        targeted_message_tbm,
-                                        message,
-                                        targeted_message_psk,
-                                        epoch)
-~~~
-
-The signature is computed as follows:
-
-~~~ tls
-signature = SignWithLabel(sender_leaf_node_signature_private_key,
-              "TargetedMessageTBS", targeted_message_tbs)
-~~~
-
-The recipient computes the following:
-
-~~~ tls
-message = OpenPSK(kem_output,
-                  receiver_node_private_key,
-                  hpke_context,
-                  targeted_message_tbm,
-                  hpke_ciphertext,
-                  targeted_message_psk,
-                  epoch)
-~~~
-
-The recipient MUST verify the message authentication:
-
-~~~ tls
-VerifyWithLabel.verify(sender_leaf_node.signature_key,
-                       "TargetedMessageTBS",
-                       targeted_message_tbs,
-                       signature)
-~~~
-
-### Guidance on authentication schemes
-
-If the group’s ciphersuite does not support HPKE `mode_auth_psk`,
-implementations MUST choose `TargetedMessageAuthScheme.SignatureHPKEPsk`.
-
-If the group’s ciphersuite does support HPKE `mode_auth_psk`, implementations
-CAN choose `TargetedMessageAuthScheme.HPKEAuthPsk` if better efficiency and/or
-repudiability is desired. Implementations SHOULD consult {{Section 9.1.1 of
-!RFC9180}} beforehand.
-
 ## Content Advertisement
 
 ### Description
@@ -1382,17 +1134,6 @@ document
 
 ## MLS Wire Formats
 
-### MLS Targeted Message
-
-The `mls_targeted_message` MLS Wire Format is used to send a message to a subset
-of members of an MLS group.
-
- * Value: 0x0006 (suggested)
- * Name: mls_targeted_message
- * Recommended: Y
- * Reference: RFC XXXX
-
-
 ## MLS Extension Types
 
 ### app_data_dictionary MLS Extension
@@ -1483,14 +1224,6 @@ type is permitted in External Commits.
 
 * Value: 0x0004
 * Name: weak-multi
-* Recommended: Y
-* Reference: RFC XXXX
-
-## MLS Signature Labels
-
-### TargetedMessageTBS
-
-* Label: "TargetedMessageTBS"
 * Recommended: Y
 * Reference: RFC XXXX
 
@@ -1622,18 +1355,6 @@ recognize which messages contain AppAcks. The application can also have clients
 enforce an AppAck schedule, reporting loss if an AppAck is not received at the
 expected time.
 
-## Targeted Messages
-
-In addition to the sender authentication, Targeted Messages are authenticated by
-using a pre-shared key (PSK) between the sender and the recipient. The PSK is
-exported from the group key schedule using the label "targeted message psk".
-This ensures that the PSK is only valid for a specific group and epoch, and the
-Forward Secrecy and Post-Compromise Security guarantees of the group key
-schedule apply to the targeted messages as well. The PSK also ensures that an
-attacker needs access to the private group state in addition to the
-HPKE/signature's private keys. This improves confidentiality guarantees against
-passive attackers and authentication guarantees against active attackers.
-
 ## Content Advertisement
 
 Use of the `content_media_types` component could leak some private information
@@ -1668,6 +1389,8 @@ security of the least secure of its credential bindings.
 RFC EDITOR PLEASE DELETE THIS SECTION.
 
 draft-07
+- remove targeted messages altogether with intention to publish it as a
+  separate document
 - assign self_remove proposal to a non duplicate number (0x000a)
 - refactor TargetedMessage to no longer use structs removed from when it
 was a "safe extension"


### PR DESCRIPTION
Following the discussion in #61 and the discussion at the last IETF meeting, targeted messages will be published as a separate document. The new document will be based on #61, therefore this PR will close all issues related to targeted messages.

Fixes #15.
Fixes #57.
Fixes #59.
Fixes #62.