### PR TITLE
Add `opaque_data_dictionary` extension and OpaqueDataUpdate proposal

### DIFF
--- a/draft-ietf-mls-extensions.md
+++ b/draft-ietf-mls-extensions.md
@@ -180,13 +180,17 @@ of the extensibility mechanisms of MLS without having to define extensions
 themselves:
 
 - An `app_data_dictionary` extension type that associates application data with
-  MLS messages or with the state of the group.
+  MLS messages or with the state of the group, and an `opaque_data_dictionary`
+  GroupContext extension that associates opaque application data with the state
+  of the group.
 
 - An AppEphemeral proposal type that enables arbitrary application data to
   be associated with a Commit.
 
 - An AppDataUpdate proposal type that enables efficient updates to
-  an `app_data_dictionary` GroupContext extension.
+  an `app_data_dictionary` GroupContext extension, and an OpaqueDataUpdate
+  proposal type that enables safe updates to an `opaque_data_dictionary`
+  GroupContext extension.
 
 As with the above, information carried in these proposals and extensions is
 marked as belonging to a specific application component, so that components can
@@ -386,8 +390,9 @@ specification. The `app_data_dictionary` extension provides a generic container
 that applications can use to attach application data to these messages. Each
 usage of the extension serves a slightly different purpose:
 
-* GroupContext: Confirms that all members of the group agree on the application
-  data, and automatically distributes it to new joiners.
+* GroupContext: Confirms that all members of the group understand the structure
+  of the included components, agree on the application data, and automatically
+  distribute it to new joiners.
 
 * KeyPackage and LeafNode: Associates the application data to a particular
   client, and advertises it to the other members of the group.
@@ -419,19 +424,36 @@ GroupContext extensions. The creator of the group can set extensions
 unilaterally. Thereafter, the AppDataUpdate proposal described in the next
 section is used to update the `app_data_dictionary` extension.
 
+The `opaque_data_dictionary` GroupContext extension provides a generic container
+for opaque data. Unlike the `app_data_dictionary`, the components inside an
+`opaque_data_dictionary` do not need to be understood by each member of the
+group, however all members still MUST support `opaque_data_dictionary` extension
+if it is included.
+
+Like the `app_data_dictionary` extension in the GroupContext, the
+`opaque_data_dictionary` extension is a serialized AppDataDictionary object. Its
+entries in the `component_data` MUST  be sorted by `component_id` and there
+MUST be at most one entry for each `component_id`. The creator of the group can
+set an `opaque_data_dictionary` extension unilaterally. Thereafter, the
+OpaqueDataUpdate proposal described in the next section is used to update the
+`opaque_data_dictionary` extension.
+
 ## Updating Application Data in the GroupContext {#appdataupdate}
 
-Updating the `app_data_dictionary` with a GroupContextExtensions proposal is
-cumbersome. The application data needs to be transmitted in its entirety, along
-with any other extensions, whether or not they are being changed. And a
-GroupContextExtensions proposal always requires an UpdatePath, which updating
-application state never should.
+Updating the `app_data_dictionary` or `opaque_data_dictionary` extensions with a
+GroupContextExtensions proposal is cumbersome. The application data needs to be
+transmitted in its entirety, along with any other extensions, whether or not
+they are being changed. And a GroupContextExtensions proposal always requires an
+UpdatePath, which updating application state never should require.
 
 The AppDataUpdate proposal allows the `app_data_dictionary` extension to be
 updated without these costs. Instead of sending the whole value of the
 extension, it sends only an update, which is interpreted by the application to
-provide the new content for the `app_data_dictionary` extension. No other
-extensions are sent or updated, and no UpdatePath is required.
+provide the new content for one components of the `app_data_dictionary`
+extension. Each member of the group needs to understand the update format of
+each component in the `app_data_dictionary` that appears in the GroupContext. No
+other extensions are sent or updated in the same proposal, and no UpdatePath is
+required.
 
 ~~~
 enum {
@@ -452,6 +474,25 @@ struct {
 } AppDataUpdate;
 ~~~
 
+The OpaqueDataUpdate proposal allows the `opaque_data_dictionary` extension to
+be updated in a similar manner, except that the update of any component in the
+`opaque_data_dictionary` extension is always a complete replacement of the
+`data` of that component with the `new_data` field from the proposal. This
+allows members that do not understand a component of the OpaqueDataUpdate to
+process updates correctly, and still construct the correct GroupContext.
+
+~~~
+struct {
+    ComponentID component_id;
+    AppDataUpdateOperation op;
+
+    select (OpaqueDataUpdate.op) {
+        case update: opaque new_data<V>;
+        case remove: struct{};
+    };
+} OpaqueDataUpdate;
+~~~
+
 An AppDataUpdate proposal is invalid if its `component_id` references a
 component that is not known to the application, or if it specifies the removal
 of state for a `component_id` that has no state present. A proposal list is
@@ -461,23 +502,51 @@ the same `component_id`. In other words, for a given `component_id`, a proposal
 list is valid only if it contains (a) a single `remove` operation or (b) one or
 more `update` operation.
 
+An OpaqueDataUpdate proposal is invalid if it specifies the removal
+of state for a `component_id` that has no state present. A proposal list is
+invalid if it includes multiple OpaqueDataUpdate proposals that `remove` state
+for the same `component_id`, or proposals that both `update` and `remove` state
+for the same `component_id`.
+
+<!--
+The processing order of default proposals and the proposal types defined in this
+document are as follows:
+
+- Zero or one GroupContextExtensions proposal,
+- Any Update proposals,
+- Any SelfRemove proposals,
+- Any Remove proposals,
+- Any Add proposals,
+- Any PreSharedKey proposals,
+- Zero or one ExternalInit proposal,
+- Zero or one ReInit proposal,
+- Any AppEphemeral proposals,
+- Any AppDataUpdate proposals,
+- Any OpaqueDataUpdate proposals
+-->
+
 AppDataUpdate proposals are processed after any default proposals (i.e., those
 defined in {{RFC9420}}), and any AppEphemeral proposals (defined in
-{{app-ephemeral}}).
+{{app-ephemeral}}). OpaqueDataUpdate proposals are process after any
+AppDataUpdate proposals.
 
-When an MLS group contains the AppDataUpdate proposal type in the
-`proposal_types` list in the group's `required_capabilities` extension, a
-GroupContextExtensions proposal MUST NOT add, remove, or modify the
-`app_data_dictionary` GroupContext extension. In other words, when every member
-of the group supports the AppDataUpdate proposal, a GroupContextExtensions
-proposal could be sent to update some other extension(s), but the
-`app_data_dictionary` GroupContext extension, if it exists, is left as it was.
+When an MLS group contains either the AppDataUpdate proposal type or the
+OpaqueDataUpdate proposal type in the `proposal_types` list in the group's
+`required_capabilities` extension, a GroupContextExtensions proposal MUST NOT
+add, remove, or modify either the `app_data_dictionary` GroupContext extension
+or the `opaque_data_dictionary` GroupContext extension. In other words, when
+every member of the group supports either the AppDataUpdate proposal or the
+OpaqueDataUpdate proposal, a GroupContextExtensions proposal could be sent to
+update some other extension(s), but the `app_data_dictionary` GroupContext
+extension and the `opaque_data_dictionary`, if either or both exist, is left as
+it was.
 
 A commit can contain a GroupContextExtensions proposal which modifies
-GroupContext extensions other than `app_data_dictionary`, and can be followed by
-zero or more AppDataUpdate proposals. This allows modifications to both the
-`app_data_dictionary` extension (via AppDataUpdate) and other extensions (via
-GroupContextExtensions) in the same Commit.
+GroupContext extensions other than `app_data_dictionary` or
+`opaque_data_dictionary`, and can be followed by zero or more AppDataUpdate
+proposals and zero or more OpaqueDataUpdate proposal. This allows modifications
+to both the `app_data_dictionary` extension (via AppDataUpdate) and other
+extensions (via GroupContextExtensions) in the same Commit.
 
 A client applies AppDataUpdate proposals by component ID. For each
 `component_id` field that appears in an AppDataUpdate proposal in the Commit,
@@ -521,18 +590,27 @@ following way:
 
 * Otherwise, the proposal list is invalid.
 
-> NOTE: Putting large amounts of data into the `app_data_dictionary` GCE may have
-> a performance impact.
+> NOTE: Putting large amounts of data into either the `app_data_dictionary` or
+> the `opaque_data_dictionary` GroupContext extensions may have a performance
+> impact.
 
-AppDataUpdate proposals do not require an UpdatePath. An AppDataUpdate proposal
-can be sent by an external sender. Likewise, AppDataUpdate proposals can be
-included in an external commit. Applications can make more restrictive validity
-rules for the update of their components, such that some components would not be
+Likewise, a client applies OpaqueDataUpdate proposals in the same way as an
+AppDataUpdate proposal, except that an OpaqueDataUpdate proposal modifies the
+`opaque_data_dictionary` instead of the `app_data_dictionary`, and when
+processing an `op` field set to `update`, it skips the first three bullet items
+regarding application logic.
+
+Neither AppDataUpdate proposals nor OpaqueDataUpdate proposal require an
+UpdatePath. Both AppDataUpdate and OpaqueDataUpdate proposals can be sent by an
+external sender, and both proposal types can be included in an external commit.
+Applications can make more restrictive validity rules for the update of their
+components in an AppDataUpdate proposal, such that some components would not be
 valid at the application when sent in an external commit or via an external
 proposer.
 
-To avoid storing large amounts of data in the `app_data_dictionary` GCE,
-implementations MAY offer storing only a hash of the actual data in the GCE.
+To avoid storing large amounts of data in the `app_data_dictionary` or
+`opaque_data_dictionary` GroupContext extensions, implementations MAY decide to
+store only a hash of the actual data in the GroupContext.
 
 ## Attaching Application Data to a Commit {#app-ephemeral}
 
@@ -1174,6 +1252,18 @@ all MLS members of the group to support.
 * Recommended: Y
 * Reference: RFC XXXX
 
+### opaque_data_dictionary MLS Extension
+
+The `opaque_data_dictionary` MLS Extension Type is used inside GroupContext
+objects. It contains a sorted list of application component data objects (at
+most one per component).
+
+* Value: 0x000b (suggested)
+* Name: opaque_data_dictionary
+* Message(s): GC: This extension may appear in GroupContext objects
+* Recommended: Y
+* Reference: RFC XXXX
+
 
 ## MLS Proposal Types
 
@@ -1211,15 +1301,16 @@ type is permitted in External Commits.
 * External: N
 * Path Required: Y
 
-### AppAck Proposal
+### OpaqueDataUpdate Proposal
 
-The `app_ack` MLS Proposal Type can be used by group members to acknowledge the
-receipt of application messages.
+The `opaque_data_update` MLS Proposal Type is used to efficiently update
+application component data stored in the `opaque_data_dictionary` GroupContext
+extension.
 
 * Value: 0x000b (suggested)
-* Name: app_ack
+* Name: opaque_data_update
 * Recommended: Y
-* External: N
+* External: Y
 * Path Required: N
 
 ## MLS Credential Types {#iana-creds}


### PR DESCRIPTION
This is a pretty heavy response to Issue #74 .

It creates both a separate `opaque_data_dictionary` extension AND a new OpaqueDataDictionary Proposal.

It actually touches quite a lot of text.

Rather than creating a separate proposal, we could use a new op code for opaque_update. I can writeup a separate PR for that option.

Incidentally this also fixes #85 
